### PR TITLE
Add <license> section to grizzly-npn pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,12 @@
             <organizationUrl>http://www.oracle.com</organizationUrl>
         </developer>
     </developers>
+    <licenses>
+        <license>
+            <name>CDDL+GPL</name>
+            <url>http://glassfish.java.net/public/CDDL+GPL.html</url>
+        </license>
+    </licenses>
     <scm>
         <connection>scm:git:git://java.net/grizzly~npn</connection>
         <developerConnection>


### PR DESCRIPTION
This is copied from https://github.com/javaee/grizzly/blob/master/pom.xml#L101

The LICENSE.txt files in each repo appear to match, although they are line-wrapped differently:

* https://github.com/javaee/grizzly/blob/master/LICENSE.txt for grizzly, is wrapped
* https://github.com/javaee/grizzly-npn/blob/master/LICENSE.txt for grizzly-npn is one-para-per-line.