### PR TITLE
Fix for grizzly-npn support for JDK8u161/JDK8u162

### DIFF
--- a/bootstrap/src/main/java/sun/security/ssl/ExtensionType.java
+++ b/bootstrap/src/main/java/sun/security/ssl/ExtensionType.java
@@ -58,7 +58,7 @@ final class ExtensionType {
         return name;
     }
 
-    static List<ExtensionType> knownExtensions = new ArrayList<ExtensionType>(9);
+    static List<ExtensionType> knownExtensions = new ArrayList<ExtensionType>(14);
 
     static ExtensionType get(int id) {
         for (ExtensionType ext : knownExtensions) {
@@ -110,6 +110,10 @@ final class ExtensionType {
     // extensions defined in RFC 5246
     final static ExtensionType EXT_SIGNATURE_ALGORITHMS =
             e(0x000D, "signature_algorithms");   // IANA registry value: 13
+
+    // extensions defined in RFC 7627
+    static final ExtensionType EXT_EXTENDED_MASTER_SECRET =
+            e(0x0017, "extended_master_secret"); // IANA registry value: 23
 
     // extensions defined in RFC 5746
     final static ExtensionType EXT_RENEGOTIATION_INFO =

--- a/bootstrap/src/main/java/sun/security/ssl/HandshakeMessage.java
+++ b/bootstrap/src/main/java/sun/security/ssl/HandshakeMessage.java
@@ -439,6 +439,10 @@ public abstract class HandshakeMessage {
         }
         // END GRIZZLY NPN
 
+        void addExtendedMasterSecretExtension() {
+            extensions.add(new ExtendedMasterSecretExtension());
+        }
+
         @Override
         int messageType() { return ht_client_hello; }
 
@@ -1175,7 +1179,7 @@ public abstract class HandshakeMessage {
             ECParameterSpec params = publicKey.getParams();
             ECPoint point = publicKey.getW();
             pointBytes = JsseJce.encodePoint(point, params.getCurve());
-            curveId = SupportedEllipticCurvesExtension.getCurveIndex(params);
+            curveId = EllipticCurvesExtension.getCurveIndex(params);
 
             if (privateKey == null) {
                 // ECDH_anon
@@ -1189,7 +1193,7 @@ public abstract class HandshakeMessage {
             } else {
                 sig = getSignature(privateKey.getAlgorithm());
             }
-            sig.initSign(privateKey);  // where is the SecureRandom?
+            sig.initSign(privateKey, sr);
 
             updateSignature(sig, clntNonce, svrNonce);
             signatureBytes = sig.sign();
@@ -1213,13 +1217,11 @@ public abstract class HandshakeMessage {
             // the supported curves during the exchange of the Hello messages.
             if (curveType == CURVE_NAMED_CURVE) {
                 curveId = input.getInt16();
-                if (SupportedEllipticCurvesExtension.isSupported(curveId)
-                        == false) {
+                if (!EllipticCurvesExtension.isSupported(curveId)) {
                     throw new SSLHandshakeException(
                             "Unsupported curveId: " + curveId);
                 }
-                String curveOid =
-                        SupportedEllipticCurvesExtension.getCurveOid(curveId);
+                String curveOid = EllipticCurvesExtension.getCurveOid(curveId);
                 if (curveOid == null) {
                     throw new SSLHandshakeException(
                             "Unknown named curve: " + curveId);

--- a/bootstrap/src/main/java/sun/security/ssl/HelloExtensions.java
+++ b/bootstrap/src/main/java/sun/security/ssl/HelloExtensions.java
@@ -64,8 +64,8 @@ import javax.net.ssl.*;
  *      explicitly support.
  *  . ServerNameExtension: the server_name extension.
  *  . SignatureAlgorithmsExtension: the signature_algorithms extension.
- *  . SupportedEllipticCurvesExtension: the ECC supported curves extension.
- *  . SupportedEllipticPointFormatsExtension: the ECC supported point formats
+ *  . EllipticCurvesExtension: the ECC supported curves extension.
+ *  . EllipticPointFormatsExtension: the ECC supported point formats
  *      (compressed/uncompressed) extension.
  *
  * @since   1.6
@@ -94,18 +94,19 @@ final class HelloExtensions {
             } else if (extType == ExtensionType.EXT_SIGNATURE_ALGORITHMS) {
                 extension = new SignatureAlgorithmsExtension(s, extlen);
             } else if (extType == ExtensionType.EXT_ELLIPTIC_CURVES) {
-                extension = new SupportedEllipticCurvesExtension(s, extlen);
+                extension = new EllipticCurvesExtension(s, extlen);
             } else if (extType == ExtensionType.EXT_EC_POINT_FORMATS) {
-                extension =
-                        new SupportedEllipticPointFormatsExtension(s, extlen);
+                extension = new EllipticPointFormatsExtension(s, extlen);
             } else if (extType == ExtensionType.EXT_RENEGOTIATION_INFO) {
                 extension = new RenegotiationInfoExtension(s, extlen);
             // BEGIN GRIZZLY NPN
             } else if (extType == ExtensionType.EXT_NEXT_PROTOCOL_NEGOTIATION) {
                 extension = NextProtocolNegotiationExtension.builder().handshakeIn(s, extlen).build();
             } else if (extType == ExtensionType.EXT_APPLICATION_LEVEL_PROTOCOL_NEGOTIATION) {
-                                extension = AlpnExtension.builder().handshakeIn(s, extlen).build();
+                extension = AlpnExtension.builder().handshakeIn(s, extlen).build();
             // END GRIZZLY NPN
+            } else if (extType == ExtensionType.EXT_EXTENDED_MASTER_SECRET) {
+                extension = new ExtendedMasterSecretExtension(s, extlen);
             } else {
                 extension = new UnknownExtension(s, extlen, extType);
             }

--- a/bootstrap/src/main/java/sun/security/ssl/ServerHandshaker.java
+++ b/bootstrap/src/main/java/sun/security/ssl/ServerHandshaker.java
@@ -110,7 +110,7 @@ final class ServerHandshaker extends Handshaker {
     private ProtocolVersion clientRequestedVersion;
 
     // client supported elliptic curves
-    private SupportedEllipticCurvesExtension requestedCurves;
+    private EllipticCurvesExtension requestedCurves;
 
     // the preferable signature algorithm used by ServerKeyExchange message
     SignatureAndHashAlgorithm preferableSignatureAlgorithm;
@@ -152,13 +152,17 @@ final class ServerHandshaker extends Handshaker {
             useSmartEphemeralDHKeys = false;
 
             try {
+                // DH parameter generation can be extremely slow, best to
+                // use one of the supported pre-computed DH parameters
+                // (see DHCrypt class).
                 customizedDHKeySize = Integer.parseUnsignedInt(property);
-                if (customizedDHKeySize < 1024 || customizedDHKeySize > 2048) {
+                if (customizedDHKeySize < 1024 || customizedDHKeySize > 8192 ||
+                        (customizedDHKeySize & 0x3f) != 0) {
                     throw new IllegalArgumentException(
                             "Unsupported customized DH key size: " +
                                     customizedDHKeySize + ". " +
-                                    "The key size can only range from 1024" +
-                                    " to 2048 (inclusive)");
+                                    "The key size must be multiple of 64, " +
+                                    "and can only range from 1024 to 8192 (inclusive)");
                 }
             } catch (NumberFormatException nfe) {
                 throw new IllegalArgumentException(
@@ -300,6 +304,11 @@ final class ServerHandshaker extends Handshaker {
                     default:
                         throw new SSLProtocolException
                                 ("Unrecognized key exchange: " + keyExchange);
+                }
+
+                // Need to add the hash for RFC 7627.
+                if (session.getUseExtendedMasterSecret()) {
+                    input.digestNow();
                 }
 
                 //
@@ -533,6 +542,26 @@ final class ServerHandshaker extends Handshaker {
             }
         }
 
+        // check out the "extended_master_secret" extension
+        if (useExtendedMasterSecret) {
+            ExtendedMasterSecretExtension extendedMasterSecretExtension =
+                    (ExtendedMasterSecretExtension)mesg.extensions.get(
+                            ExtensionType.EXT_EXTENDED_MASTER_SECRET);
+            if (extendedMasterSecretExtension != null) {
+                requestedToUseEMS = true;
+            } else if (mesg.protocolVersion.v >= ProtocolVersion.TLS10.v) {
+                if (!allowLegacyMasterSecret) {
+                    // For full handshake, if the server receives a ClientHello
+                    // without the extension, it SHOULD abort the handshake if
+                    // it does not wish to interoperate with legacy clients.
+                    //
+                    // As if extended master extension is required for full
+                    // handshake, it MUST be used in abbreviated handshake too.
+                    fatalSE(Alerts.alert_handshake_failure,
+                            "Extended Master Secret extension is required");
+                }
+            }
+        }
         // BEGIN GRIZZLY NPN
         NextProtocolNegotiationExtension responseExtension = null;
         if (isInitialHandshake) {
@@ -645,8 +674,42 @@ final class ServerHandshaker extends Handshaker {
                 if (resumingSession) {
                     ProtocolVersion oldVersion = previous.getProtocolVersion();
                     // cannot resume session with different version
-                    if (oldVersion != protocolVersion) {
+                    if (oldVersion != mesg.protocolVersion) {
                         resumingSession = false;
+                    }
+                }
+
+                if (resumingSession && useExtendedMasterSecret) {
+                    if (requestedToUseEMS &&
+                            !previous.getUseExtendedMasterSecret()) {
+                        // For abbreviated handshake request, If the original
+                        // session did not use the "extended_master_secret"
+                        // extension but the new ClientHello contains the
+                        // extension, then the server MUST NOT perform the
+                        // abbreviated handshake.  Instead, it SHOULD continue
+                        // with a full handshake.
+                        resumingSession = false;
+                    } else if (!requestedToUseEMS &&
+                            previous.getUseExtendedMasterSecret()) {
+                        // For abbreviated handshake request, if the original
+                        // session used the "extended_master_secret" extension
+                        // but the new ClientHello does not contain it, the
+                        // server MUST abort the abbreviated handshake.
+                        fatalSE(Alerts.alert_handshake_failure,
+                                "Missing Extended Master Secret extension " +
+                                        "on session resumption");
+                    } else if (!requestedToUseEMS &&
+                            !previous.getUseExtendedMasterSecret()) {
+                        // For abbreviated handshake request, if neither the
+                        // original session nor the new ClientHello uses the
+                        // extension, the server SHOULD abort the handshake.
+                        if (!allowLegacyResumption) {
+                            fatalSE(Alerts.alert_handshake_failure,
+                                    "Missing Extended Master Secret extension " +
+                                            "on session resumption");
+                        } else {  // Otherwise, continue with a full handshake.
+                            resumingSession = false;
+                        }
                     }
                 }
 
@@ -763,7 +826,7 @@ final class ServerHandshaker extends Handshaker {
                 throw new SSLException("Client did not resume a session");
             }
 
-            requestedCurves = (SupportedEllipticCurvesExtension)
+            requestedCurves = (EllipticCurvesExtension)
                     mesg.extensions.get(ExtensionType.EXT_ELLIPTIC_CURVES);
 
             // We only need to handle the "signature_algorithm" extension
@@ -796,7 +859,9 @@ final class ServerHandshaker extends Handshaker {
             session = new SSLSessionImpl(protocolVersion, CipherSuite.C_NULL,
                     getLocalSupportedSignAlgs(),
                     sslContext.getSecureRandom(),
-                    getHostAddressSE(), getPortSE());
+                    getHostAddressSE(), getPortSE(),
+                    (requestedToUseEMS &&
+                            (protocolVersion.v >= ProtocolVersion.TLS10.v)));
 
             if (protocolVersion.v >= ProtocolVersion.TLS12.v) {
                 if (peerSupportedSignAlgs != null) {
@@ -860,7 +925,9 @@ final class ServerHandshaker extends Handshaker {
                 m1.extensions.add(serverHelloSNI);
             }
         }
-
+        if (session.getUseExtendedMasterSecret()) {
+            m1.extensions.add(new ExtendedMasterSecretExtension());
+        }
         // BEGIN GRIZZLY NPN
         if (responseExtension != null) {
             m1.extensions.add(responseExtension);
@@ -1471,14 +1538,10 @@ final class ServerHandshaker extends Handshaker {
          * Applications may also want to customize the ephemeral DH key size
          * to a fixed length for non-exportable cipher suites. This can be
          * approached by setting system property "jdk.tls.ephemeralDHKeySize"
-         * to a valid positive integer between 1024 and 2048 bits, inclusive.
+         * to a valid positive integer between 1024 and 8192 bits, inclusive.
          *
          * Note that the minimum acceptable key size is 1024 bits except
          * exportable cipher suites or legacy mode.
-         *
-         * Note that the maximum acceptable key size is 2048 bits because
-         * DH keys bigger than 2048 are not always supported by underlying
-         * JCE providers.
          *
          * Note that per RFC 2246, the key size limit of DH is 512 bits for
          * exportable cipher suites.  Because of the weakness, exportable
@@ -1494,10 +1557,17 @@ final class ServerHandshaker extends Handshaker {
             } else if (useSmartEphemeralDHKeys) {    // matched mode
                 if (key != null) {
                     int ks = KeyUtil.getKeySize(key);
-                    // Note that SunJCE provider only supports 2048 bits DH
-                    // keys bigger than 1024.  Please DON'T use value other
-                    // than 1024 and 2048 at present.  We may improve the
-                    // underlying providers and key size here in the future.
+
+                    // DH parameter generation can be extremely slow, make
+                    // sure to use one of the supported pre-computed DH
+                    // parameters (see DHCrypt class).
+                    //
+                    // Old deployed applications may not be ready to support
+                    // DH key sizes bigger than 2048 bits.  Please DON'T use
+                    // value other than 1024 and 2048 at present.  May improve
+                    // the underlying providers and key size limit in the
+                    // future when the compatibility and interoperability
+                    // impact is limited.
                     //
                     // keySize = ks <= 1024 ? 1024 : (ks >= 2048 ? 2048 : ks);
                     keySize = ks <= 1024 ? 1024 : 2048;
@@ -1516,7 +1586,7 @@ final class ServerHandshaker extends Handshaker {
     private boolean setupEphemeralECDHKeys() {
         int index = (requestedCurves != null) ?
                 requestedCurves.getPreferredCurve(algorithmConstraints) :
-                SupportedEllipticCurvesExtension.getActiveCurves(algorithmConstraints);
+                EllipticCurvesExtension.getActiveCurves(algorithmConstraints);
         if (index < 0) {
             // no match found, cannot use this ciphersuite
             return false;
@@ -1571,8 +1641,8 @@ final class ServerHandshaker extends Handshaker {
                 return false;
             }
             ECParameterSpec params = ((ECPublicKey)publicKey).getParams();
-            int id = SupportedEllipticCurvesExtension.getCurveIndex(params);
-            if ((id <= 0) || !SupportedEllipticCurvesExtension.isSupported(id) ||
+            int id = EllipticCurvesExtension.getCurveIndex(params);
+            if ((id <= 0) || !EllipticCurvesExtension.isSupported(id) ||
                     ((requestedCurves != null) && !requestedCurves.contains(id))) {
                 return false;
             }


### PR DESCRIPTION
Fix for Issue_4: https://github.com/javaee/grizzly-npn/issues/4
Support for Extended master secret implemented in JDK 8u161+